### PR TITLE
Update linkedin link preview image

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,13 +10,13 @@
     <meta property="og:title" content="Spremt Labs - We solve problems" />
     <meta property="og:description" content="We work with great people to take the action needed to solve problems" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="/social-preview.png" />
+    <meta property="og:image" content="/SpremtLabs_LinkedIn_Fit.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Spremt Labs - We solve problems" />
     <meta name="twitter:description" content="We work with great people to take the action needed to solve problems" />
-    <meta name="twitter:image" content="/social-preview.png" />
+    <meta name="twitter:image" content="/SpremtLabs_LinkedIn_Fit.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -10,13 +10,17 @@
     <meta property="og:title" content="Spremt Labs - We solve problems" />
     <meta property="og:description" content="We work with great people to take the action needed to solve problems" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="/SpremtLabs_LinkedIn_Fit.png" />
+    <meta property="og:url" content="https://spremtlabs.com" />
+    <meta property="og:site_name" content="Spremt Labs" />
+    <meta property="og:image" content="https://spremtlabs.com/SpremtLabs_LinkedIn_Fit.png" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Spremt Labs - We solve problems" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Spremt Labs - We solve problems" />
     <meta name="twitter:description" content="We work with great people to take the action needed to solve problems" />
-    <meta name="twitter:image" content="/SpremtLabs_LinkedIn_Fit.png" />
+    <meta name="twitter:image" content="https://spremtlabs.com/SpremtLabs_LinkedIn_Fit.png" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Update Open Graph and Twitter image meta tags to use `SpremtLabs_LinkedIn_Fit.png` for social media link previews.

---
<a href="https://cursor.com/background-agent?bcId=bc-4faa6c18-cee9-4002-9256-7d805f2e483c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4faa6c18-cee9-4002-9256-7d805f2e483c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

